### PR TITLE
Fixed MandatoryFieldsException  for only 1 lang center

### DIFF
--- a/pre-registration/pre-registration-application-service/src/main/java/io/mosip/preregistration/application/service/util/NotificationServiceUtil.java
+++ b/pre-registration/pre-registration-application-service/src/main/java/io/mosip/preregistration/application/service/util/NotificationServiceUtil.java
@@ -401,6 +401,13 @@ public class NotificationServiceUtil {
 							firstRegCenterLangCode = regCenterLangCode;	
 						}
 						regCentersMap.put(regCenterLangCode, centerDto);
+					} else {
+						centerDto = getNotificationCenterAddressDTO(registrationCenterId,
+								"all");
+						if (firstRegCenterLangCode == null) {
+							firstRegCenterLangCode = regCenterLangCode;	
+						}
+						regCentersMap.put(regCenterLangCode, centerDto);
 					}
 				}
 				RegistrationCenterDto defaultCenterDto = null;


### PR DESCRIPTION
Fixed Mandatory Fields exception in Notification service when application is created in "eng", "fra" and appointment is booked with a RegCenter created only in "ara"