### PR TITLE
MOSIP-39719 - Added a log level for the commons classes

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testrunner/MosipTestRunner.java
@@ -23,6 +23,7 @@ import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 
 import io.mosip.testrig.apirig.prereg.utils.PreRegConfigManager;
+import io.mosip.testrig.apirig.prereg.utils.PreRegUtil;
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.testrunner.ExtractResource;
 import io.mosip.testrig.apirig.testrunner.HealthChecker;
@@ -32,7 +33,9 @@ import io.mosip.testrig.apirig.utils.AuthTestsUtil;
 import io.mosip.testrig.apirig.utils.CertsUtil;
 import io.mosip.testrig.apirig.utils.ConfigManager;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
+import io.mosip.testrig.apirig.utils.GlobalMethods;
 import io.mosip.testrig.apirig.utils.JWKKeyUtil;
+import io.mosip.testrig.apirig.utils.KernelAuthentication;
 import io.mosip.testrig.apirig.utils.KeyCloakUserAndAPIKeyGeneration;
 import io.mosip.testrig.apirig.utils.KeycloakUserManager;
 import io.mosip.testrig.apirig.utils.MispPartnerAndLicenseKeyGeneration;
@@ -61,12 +64,8 @@ public class MosipTestRunner {
 	public static void main(String[] arg) {
 
 		try {
-
-			Map<String, String> envMap = System.getenv();
-			LOGGER.info("** ------------- Get ALL ENV varibales --------------------------------------------- **");
-			for (String envName : envMap.keySet()) {
-				LOGGER.info(String.format("ENV %s = %s%n", envName, envMap.get(envName)));
-			}
+			LOGGER.info("** ------------- API Test Rig Run Started --------------------------------------------- **");
+			
 			BaseTestCase.setRunContext(getRunType(), jarUrl);
 			ExtractResource.removeOldMosipTestTestResource();
 			if (getRunType().equalsIgnoreCase("JAR")) {
@@ -78,6 +77,7 @@ public class MosipTestRunner {
 			PreRegConfigManager.init();
 			suiteSetup(getRunType());
 			SkipTestCaseHandler.loadTestcaseToBeSkippedList("testCaseSkippedList.txt");
+			GlobalMethods.setModuleNameAndReCompilePattern(PreRegConfigManager.getproperty("moduleNamePattern"));
 			setLogLevels();
 			AdminTestUtil.getRequiredField();
 
@@ -134,6 +134,9 @@ public class MosipTestRunner {
 		MispPartnerAndLicenseKeyGeneration.setLogLevel();
 		JWKKeyUtil.setLogLevel();
 		CertsUtil.setLogLevel();
+		KernelAuthentication.setLogLevel();
+		BaseTestCase.setLogLevel();
+		PreRegUtil.setLogLevel();
 	}
 
 	/**

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/utils/PreRegConfigManager.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/utils/PreRegConfigManager.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
 import io.mosip.testrig.apirig.prereg.testrunner.MosipTestRunner;
@@ -13,6 +14,9 @@ public class PreRegConfigManager extends ConfigManager{
 	private static final Logger LOGGER = Logger.getLogger(PreRegConfigManager.class);
 	
 	public static void init() {
+		Logger configManagerLogger = Logger.getLogger(ConfigManager.class);
+		configManagerLogger.setLevel(Level.WARN);
+		
 		Map<String, Object> moduleSpecificPropertiesMap = new HashMap<>();
 		// Load scope specific properties
 		try {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/utils/PreRegUtil.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/utils/PreRegUtil.java
@@ -1,5 +1,6 @@
 package io.mosip.testrig.apirig.prereg.utils;
 
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.json.JSONArray;
 import org.testng.SkipException;
@@ -12,6 +13,13 @@ import io.mosip.testrig.apirig.utils.SkipTestCaseHandler;
 public class PreRegUtil extends AdminTestUtil {
 
 	private static final Logger logger = Logger.getLogger(PreRegUtil.class);
+	
+	public static void setLogLevel() {
+		if (PreRegConfigManager.IsDebugEnabled())
+			logger.setLevel(Level.ALL);
+		else
+			logger.setLevel(Level.ERROR);
+	}
 	
 	public static String isTestCaseValidForExecution(TestCaseDTO testCaseDTO) {
 		String testCaseName = testCaseDTO.getTestCaseName();


### PR DESCRIPTION
The setLogLevel method was added to the commons classes to prevent sensitive information, like secrets, from being printed in the console logs.