### PR TITLE
MOSIP-38060 - fix PII data present in database in unencoded format

### DIFF
--- a/pre-registration/pre-registration-batchjob/src/main/java/io/mosip/preregistration/batchjob/entity/DocumentEntityConsumed.java
+++ b/pre-registration/pre-registration-batchjob/src/main/java/io/mosip/preregistration/batchjob/entity/DocumentEntityConsumed.java
@@ -7,10 +7,8 @@ package io.mosip.preregistration.batchjob.entity;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import io.mosip.preregistration.core.converter.Base64StringConverter;
+import jakarta.persistence.*;
 
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -85,6 +83,7 @@ public class DocumentEntityConsumed implements Serializable {
 	 * Created By
 	 */
 	@Column(name = "cr_by")
+	@Convert(converter = Base64StringConverter.class)
 	private String crBy;
 
 	/**
@@ -97,6 +96,7 @@ public class DocumentEntityConsumed implements Serializable {
 	 * Updated By
 	 */
 	@Column(name = "upd_by")
+	@Convert(converter = Base64StringConverter.class)
 	private String updBy;
 
 	/**

--- a/pre-registration/pre-registration-core/src/main/java/io/mosip/preregistration/core/common/entity/DemographicEntity.java
+++ b/pre-registration/pre-registration-core/src/main/java/io/mosip/preregistration/core/common/entity/DemographicEntity.java
@@ -8,16 +8,12 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import io.mosip.preregistration.core.converter.Base64StringConverter;
+import jakarta.persistence.*;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.NamedQuery;
 import org.springframework.stereotype.Component;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -71,10 +67,12 @@ public class DemographicEntity implements Serializable {
 
 	/** The created by. */
 	@Column(name = "cr_by")
+	@Convert(converter = Base64StringConverter.class)
 	private String createdBy;
 
 	/** The created appuser by. */
 	@Column(name = "cr_appuser_id")
+	@Convert(converter = Base64StringConverter.class)
 	private String crAppuserId;
 
 	/** The create date time. */
@@ -83,6 +81,7 @@ public class DemographicEntity implements Serializable {
 
 	/** The updated by. */
 	@Column(name = "upd_by")
+	@Convert(converter = Base64StringConverter.class)
 	private String updatedBy;
 
 	/** The update date time. */

--- a/pre-registration/pre-registration-core/src/main/java/io/mosip/preregistration/core/common/entity/DocumentEntity.java
+++ b/pre-registration/pre-registration-core/src/main/java/io/mosip/preregistration/core/common/entity/DocumentEntity.java
@@ -7,14 +7,8 @@ package io.mosip.preregistration.core.common.entity;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.NamedQuery;
-import jakarta.persistence.Table;
+import io.mosip.preregistration.core.converter.Base64StringConverter;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -97,6 +91,7 @@ public class DocumentEntity implements Serializable {
 	 * Created By
 	 */
 	@Column(name = "cr_by")
+	@Convert(converter = Base64StringConverter.class)
 	private String crBy;
 
 	/**
@@ -109,6 +104,7 @@ public class DocumentEntity implements Serializable {
 	 * Updated By
 	 */
 	@Column(name = "upd_by")
+	@Convert(converter = Base64StringConverter.class)
 	private String updBy;
 
 	/**

--- a/pre-registration/pre-registration-core/src/main/java/io/mosip/preregistration/core/converter/Base64StringConverter.java
+++ b/pre-registration/pre-registration-core/src/main/java/io/mosip/preregistration/core/converter/Base64StringConverter.java
@@ -1,0 +1,26 @@
+package io.mosip.preregistration.core.converter;
+
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+
+@Converter
+public class Base64StringConverter implements AttributeConverter<String, String> {
+
+    @Override
+    public String convertToDatabaseColumn(String attribute) {
+        if (attribute == null) return null;
+        return Base64.getEncoder().encodeToString(attribute.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public String convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        byte[] decodedBytes = Base64.getDecoder().decode(dbData);
+        return new String(decodedBytes, StandardCharsets.UTF_8);
+    }
+}

--- a/pre-registration/pre-registration-datasync-service/src/main/java/io/mosip/preregistration/datasync/entity/DemographicEntityConsumed.java
+++ b/pre-registration/pre-registration-datasync-service/src/main/java/io/mosip/preregistration/datasync/entity/DemographicEntityConsumed.java
@@ -7,12 +7,10 @@ package io.mosip.preregistration.datasync.entity;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 
+import io.mosip.preregistration.core.converter.Base64StringConverter;
+import jakarta.persistence.*;
 import org.springframework.stereotype.Component;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
@@ -60,10 +58,12 @@ public class DemographicEntityConsumed implements Serializable {
 
 	/** The created by. */
 	@Column(name = "cr_by")
+	@Convert(converter = Base64StringConverter.class)
 	private String createdBy;
 
 	/** The created appuser by. */
 	@Column(name = "cr_appuser_id")
+	@Convert(converter = Base64StringConverter.class)
 	private String crAppuserId;
 
 	/** The create date time. */
@@ -72,6 +72,7 @@ public class DemographicEntityConsumed implements Serializable {
 
 	/** The updated by. */
 	@Column(name = "upd_by")
+	@Convert(converter = Base64StringConverter.class)
 	private String updatedBy;
 
 	/** The update date time. */


### PR DESCRIPTION
Fix PII data stored in PreReg DB as plaintext in the following tables :
- <applicant_demographic>
- <applicant_demographic_consumed>
- <applicant_document>
- <applicant_document_consumed>

Using JPA Converter (`@Converter` & `@Convert`) mechanism and Base64.