### PR TITLE
MOSIP-40258: Standardized XSS Exception Handling in apitest-prereg Module

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -56,7 +56,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.3.2-SNAPSHOT</version>
+			<version>1.3.3-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/BookAppoinment.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/BookAppoinment.java
@@ -35,6 +35,7 @@ import io.mosip.testrig.apirig.utils.KernelAuthentication;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
 import io.mosip.testrig.apirig.utils.RestClient;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class BookAppoinment extends PreRegUtil implements ITest {
@@ -81,7 +82,7 @@ public class BookAppoinment extends PreRegUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = PreRegUtil.isTestCaseValidForExecution(testCaseDTO);
 		String regCenterId = null;
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/BookAppoinmentByPrid.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/BookAppoinmentByPrid.java
@@ -34,6 +34,7 @@ import io.mosip.testrig.apirig.utils.KernelAuthentication;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
 import io.mosip.testrig.apirig.utils.RestClient;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class BookAppoinmentByPrid extends PreRegUtil implements ITest {
@@ -79,7 +80,7 @@ public class BookAppoinmentByPrid extends PreRegUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		String regCenterId = null;
 		String appDate = null;
 		String timeSlotFrom = null;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/CreatePreReg.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/CreatePreReg.java
@@ -34,6 +34,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class CreatePreReg extends PreRegUtil implements ITest {
@@ -83,7 +84,7 @@ public class CreatePreReg extends PreRegUtil implements ITest {
 	 */
 	@Test(dataProvider = "testcaselist")
 	public void test(TestCaseDTO testCaseDTO)
-			throws AuthenticationTestException, AdminTestException, NoSuchAlgorithmException {
+			throws AuthenticationTestException, AdminTestException, NoSuchAlgorithmException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PreRegUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/DeleteWithParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/DeleteWithParam.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class DeleteWithParam extends PreRegUtil implements ITest {
@@ -74,7 +75,7 @@ public class DeleteWithParam extends PreRegUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PreRegUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/GetWithParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/GetWithParam.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class GetWithParam extends PreRegUtil implements ITest {
@@ -77,7 +78,7 @@ public class GetWithParam extends PreRegUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException{
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PreRegUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/GetWithParamForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/GetWithParamForAutoGenId.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class GetWithParamForAutoGenId extends PreRegUtil implements ITest {
@@ -79,7 +80,7 @@ public class GetWithParamForAutoGenId extends PreRegUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PreRegUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PostWithFormDataAndFileForNotificationAPI.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PostWithFormDataAndFileForNotificationAPI.java
@@ -29,6 +29,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class PostWithFormDataAndFileForNotificationAPI extends PreRegUtil implements ITest {
@@ -76,7 +77,7 @@ public class PostWithFormDataAndFileForNotificationAPI extends PreRegUtil implem
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PreRegUtil.isTestCaseValidForExecution(testCaseDTO);
 		String inputJson = getJsonFromTemplate(testCaseDTO.getInput(), testCaseDTO.getInputTemplate());

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PostWithFormPathParamAndFile.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PostWithFormPathParamAndFile.java
@@ -28,6 +28,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class PostWithFormPathParamAndFile extends PreRegUtil implements ITest {
@@ -75,7 +76,7 @@ public class PostWithFormPathParamAndFile extends PreRegUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PreRegUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PostWithPathParamsAndBody.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PostWithPathParamsAndBody.java
@@ -28,6 +28,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class PostWithPathParamsAndBody extends PreRegUtil implements ITest {
@@ -74,7 +75,7 @@ public class PostWithPathParamsAndBody extends PreRegUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = PreRegUtil.isTestCaseValidForExecution(testCaseDTO);
 		String regCenterId = null;
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PreregAuditValidator.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PreregAuditValidator.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AdminTestException;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class PreregAuditValidator extends PreRegUtil implements ITest {
@@ -68,7 +69,7 @@ public class PreregAuditValidator extends PreRegUtil implements ITest {
 	}
 
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PreRegUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PutWithPathParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PutWithPathParam.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class PutWithPathParam extends PreRegUtil implements ITest {
@@ -76,7 +77,7 @@ public class PutWithPathParam extends PreRegUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PreRegUtil.isTestCaseValidForExecution(testCaseDTO);
 		String[] templateFields = testCaseDTO.getTemplateFields();

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/SimplePost.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/SimplePost.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class SimplePost extends PreRegUtil implements ITest {
@@ -77,7 +78,7 @@ public class SimplePost extends PreRegUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PreRegUtil.isTestCaseValidForExecution(testCaseDTO);
 		auditLogCheck = testCaseDTO.isAuditLogCheck();

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/UpdatePrereg.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/UpdatePrereg.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class UpdatePrereg extends PreRegUtil implements ITest {
@@ -78,7 +79,7 @@ public class UpdatePrereg extends PreRegUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PreRegUtil.isTestCaseValidForExecution(testCaseDTO);
 		testCaseDTO.setInputTemplate(AdminTestUtil.generateHbsForPrereg(true));


### PR DESCRIPTION
Integrated SecurityXSSException in the apitest-prereg module to standardize XSS-related error handling. This ensures consistent exception throwing across the application wherever XSS protection checks fail. Improves security and maintainability by centralizing exception logic.