### PR TITLE
MOSIP-42160 updated xml with valid order for getPRIDByDateRange scenario

### DIFF
--- a/api-test/testNgXmlFiles/preregSuite.xml
+++ b/api-test/testNgXmlFiles/preregSuite.xml
@@ -103,13 +103,6 @@
 			<class name="io.mosip.testrig.apirig.prereg.testscripts.GetWithParam" />
 		</classes>
 	</test>
-	<test name="GetPRIDByDateRange">
-		<parameter name="ymlFile"
-			value="preReg/GetPRIDByDateRange/GetPRIDByDateRange.yml" />
-		<classes>
-			<class name="io.mosip.testrig.apirig.prereg.testscripts.SimplePost" />
-		</classes>
-	</test> 
 	 <test name="BookAppointment">
 		<parameter name="ymlFile"
 			value="preReg/bookAppointment/bookAppointment.yml" />
@@ -118,9 +111,13 @@
 			<class name="io.mosip.testrig.apirig.prereg.testscripts.BookAppoinment" />
 		</classes>
 	</test>
-	
-	
-	
+	<test name="GetPRIDByDateRange">
+		<parameter name="ymlFile"
+				   value="preReg/GetPRIDByDateRange/GetPRIDByDateRange.yml" />
+		<classes>
+			<class name="io.mosip.testrig.apirig.prereg.testscripts.SimplePost" />
+		</classes>
+	</test>
 	<test name="FetchAppointmentDetailsByPrid">
 		<parameter name="ymlFile"
 			value="preReg/FetchAppointmentDetailsByPrid/FetchAppointmentDetailsByPrid.yml" />


### PR DESCRIPTION
1. Updated the preregSuite.xml with valid order of flow for getPRIDByDateRange
2. As we are fetching the details with PRID within the date range, It should be executed post 'BookAppointment' scenario