### PR TITLE
[MOSIP-43615] [MOSIP-43648] [MOSIP-43434] added lifecycle, graceperio…

### DIFF
--- a/helm/prereg-application/.gitignore
+++ b/helm/prereg-application/.gitignore
@@ -1,2 +1,2 @@
 charts/
-Charts.lock
+Chart.lock

--- a/helm/prereg-application/templates/deployment.yaml
+++ b/helm/prereg-application/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 60 }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}

--- a/helm/prereg-application/values.yaml
+++ b/helm/prereg-application/values.yaml
@@ -216,7 +216,17 @@ podAnnotations: {}
 
 ## lifecycleHooks for the  container to automate configuration before or after startup.
 ##
-lifecycleHooks: {}
+lifecycleHooks:
+  preStop:
+    exec:
+      command:
+        - sh
+        - -c
+        - sleep 30
+
+## Termination grace perios : the maximum amount of time (in seconds) Kubernetes will wait for a container to gracefully shut down
+terminationGracePeriodSeconds: 60
+
 
 ## Custom Liveness probes for
 ##
@@ -314,8 +324,8 @@ volumePermissions:
   enabled: false
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
-    tag: "10"
+    repository: mosipid/os-shell
+    tag: "12-debian-12-r46"
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/helm/prereg-application/values.yaml
+++ b/helm/prereg-application/values.yaml
@@ -224,7 +224,7 @@ lifecycleHooks:
         - -c
         - sleep 30
 
-## Termination grace perios : the maximum amount of time (in seconds) Kubernetes will wait for a container to gracefully shut down
+## Termination grace period : the maximum amount of time (in seconds) Kubernetes will wait for a container to gracefully shut down
 terminationGracePeriodSeconds: 60
 
 

--- a/helm/prereg-batchjob/.gitignore
+++ b/helm/prereg-batchjob/.gitignore
@@ -1,2 +1,2 @@
 charts/
-Charts.lock
+Chart.lock

--- a/helm/prereg-batchjob/templates/deployment.yaml
+++ b/helm/prereg-batchjob/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 60 }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}

--- a/helm/prereg-batchjob/values.yaml
+++ b/helm/prereg-batchjob/values.yaml
@@ -217,7 +217,16 @@ podAnnotations: {}
 
 ## lifecycleHooks for the  container to automate configuration before or after startup.
 ##
-lifecycleHooks: {}
+lifecycleHooks:
+  preStop:
+    exec:
+      command:
+        - sh
+        - -c
+        - sleep 30
+
+## Termination grace perios : the maximum amount of time (in seconds) Kubernetes will wait for a container to gracefully shut down
+terminationGracePeriodSeconds: 60
 
 ## Custom Liveness probes for
 ##
@@ -315,8 +324,8 @@ volumePermissions:
   enabled: false
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
-    tag: "10"
+    repository: mosipid/os-shell
+    tag: "12-debian-12-r46"
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/helm/prereg-batchjob/values.yaml
+++ b/helm/prereg-batchjob/values.yaml
@@ -225,7 +225,7 @@ lifecycleHooks:
         - -c
         - sleep 30
 
-## Termination grace perios : the maximum amount of time (in seconds) Kubernetes will wait for a container to gracefully shut down
+## Termination grace period : the maximum amount of time (in seconds) Kubernetes will wait for a container to gracefully shut down
 terminationGracePeriodSeconds: 60
 
 ## Custom Liveness probes for

--- a/helm/prereg-datasync/.gitignore
+++ b/helm/prereg-datasync/.gitignore
@@ -1,2 +1,2 @@
 charts/
-Charts.lock
+Chart.lock

--- a/helm/prereg-datasync/templates/deployment.yaml
+++ b/helm/prereg-datasync/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 60 }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}

--- a/helm/prereg-datasync/values.yaml
+++ b/helm/prereg-datasync/values.yaml
@@ -216,7 +216,16 @@ podAnnotations: {}
 
 ## lifecycleHooks for the  container to automate configuration before or after startup.
 ##
-lifecycleHooks: {}
+lifecycleHooks:
+  preStop:
+    exec:
+      command:
+        - sh
+        - -c
+        - sleep 30
+
+## Termination grace perios : the maximum amount of time (in seconds) Kubernetes will wait for a container to gracefully shut down
+terminationGracePeriodSeconds: 60
 
 ## Custom Liveness probes for
 ##
@@ -314,8 +323,8 @@ volumePermissions:
   enabled: false
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
-    tag: "10"
+    repository: mosipid/os-shell
+    tag: "12-debian-12-r46"
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/pre-registration/pom.xml
+++ b/pre-registration/pom.xml
@@ -34,7 +34,7 @@
 		<maven.war.plugin.version>3.1.0</maven.war.plugin.version>
 		<maven.assembly.plugin.version>3.3.0</maven.assembly.plugin.version>
 		<maven.surefire.plugin.version>3.1.2</maven.surefire.plugin.version>
-		<spring.boot.maven.plugin.version>3.2.5</spring.boot.maven.plugin.version>
+		<spring.boot.maven.plugin.version>3.2.3</spring.boot.maven.plugin.version>
 		<central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
 		<maven.sonar.plugin.version>3.7.0.1746</maven.sonar.plugin.version>
 		<!-- git -->
@@ -208,6 +208,11 @@
 	<build>
 		<pluginManagement>
 			<plugins>
+                                <plugin>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-maven-plugin</artifactId>
+					<version>${spring.boot.maven.plugin.version}</version>
+				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
…d and updated bitnami depricated image, resources, probes and .gitignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added graceful shutdown across Helm charts: 60s termination grace period and 30s pre-stop pause.
  * Updated init/container initialization image to a newer base image version across services.
  * Adjusted build tooling: updated Spring Boot Maven plugin version in project build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->