### PR TITLE
MOSIP-41353: Remove unused config files and properties in PREREG module.

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testrunner/MosipTestRunner.java
@@ -11,7 +11,6 @@ import java.security.PublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
 import org.apache.log4j.Level;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/BookAppoinment.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/BookAppoinment.java
@@ -1,6 +1,5 @@
 package io.mosip.testrig.apirig.prereg.testscripts;
 
-import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 
@@ -18,8 +17,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.testng.internal.BaseTestMethod;
-import org.testng.internal.TestResult;
 
 import io.mosip.testrig.apirig.dto.OutputValidationDto;
 import io.mosip.testrig.apirig.dto.TestCaseDTO;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/BookAppoinmentByPrid.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/BookAppoinmentByPrid.java
@@ -1,6 +1,5 @@
 package io.mosip.testrig.apirig.prereg.testscripts;
 
-import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 
@@ -18,8 +17,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.testng.internal.BaseTestMethod;
-import org.testng.internal.TestResult;
 
 import io.mosip.testrig.apirig.dto.OutputValidationDto;
 import io.mosip.testrig.apirig.dto.TestCaseDTO;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/CreatePreReg.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/CreatePreReg.java
@@ -1,6 +1,5 @@
 package io.mosip.testrig.apirig.prereg.testscripts;
 
-import java.lang.reflect.Field;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -19,8 +18,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.testng.internal.BaseTestMethod;
-import org.testng.internal.TestResult;
 
 import io.mosip.testrig.apirig.dto.OutputValidationDto;
 import io.mosip.testrig.apirig.dto.TestCaseDTO;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/DeleteWithParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/DeleteWithParam.java
@@ -1,6 +1,5 @@
 package io.mosip.testrig.apirig.prereg.testscripts;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -17,8 +16,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.testng.internal.BaseTestMethod;
-import org.testng.internal.TestResult;
 
 import io.mosip.testrig.apirig.dto.OutputValidationDto;
 import io.mosip.testrig.apirig.dto.TestCaseDTO;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/GetWithParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/GetWithParam.java
@@ -1,6 +1,5 @@
 package io.mosip.testrig.apirig.prereg.testscripts;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -17,8 +16,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.testng.internal.BaseTestMethod;
-import org.testng.internal.TestResult;
 
 import io.mosip.testrig.apirig.dto.OutputValidationDto;
 import io.mosip.testrig.apirig.dto.TestCaseDTO;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/GetWithParamForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/GetWithParamForAutoGenId.java
@@ -1,6 +1,5 @@
 package io.mosip.testrig.apirig.prereg.testscripts;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -17,8 +16,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.testng.internal.BaseTestMethod;
-import org.testng.internal.TestResult;
 
 import io.mosip.testrig.apirig.dto.OutputValidationDto;
 import io.mosip.testrig.apirig.dto.TestCaseDTO;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PostWithFormDataAndFileForNotificationAPI.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PostWithFormDataAndFileForNotificationAPI.java
@@ -1,6 +1,5 @@
 package io.mosip.testrig.apirig.prereg.testscripts;
 
-import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 
@@ -15,8 +14,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.testng.internal.BaseTestMethod;
-import org.testng.internal.TestResult;
 
 import io.mosip.testrig.apirig.dto.OutputValidationDto;
 import io.mosip.testrig.apirig.dto.TestCaseDTO;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PostWithFormPathParamAndFile.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PostWithFormPathParamAndFile.java
@@ -1,6 +1,5 @@
 package io.mosip.testrig.apirig.prereg.testscripts;
 
-import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 
@@ -15,8 +14,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.testng.internal.BaseTestMethod;
-import org.testng.internal.TestResult;
 
 import io.mosip.testrig.apirig.dto.OutputValidationDto;
 import io.mosip.testrig.apirig.dto.TestCaseDTO;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PostWithPathParamsAndBody.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PostWithPathParamsAndBody.java
@@ -1,6 +1,5 @@
 package io.mosip.testrig.apirig.prereg.testscripts;
 
-import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 
@@ -15,8 +14,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.testng.internal.BaseTestMethod;
-import org.testng.internal.TestResult;
 
 import io.mosip.testrig.apirig.dto.OutputValidationDto;
 import io.mosip.testrig.apirig.dto.TestCaseDTO;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PreregAuditValidator.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PreregAuditValidator.java
@@ -1,6 +1,5 @@
 package io.mosip.testrig.apirig.prereg.testscripts;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -12,14 +11,11 @@ import org.apache.log4j.Logger;
 import org.testng.ITest;
 import org.testng.ITestContext;
 import org.testng.ITestResult;
-import org.testng.Reporter;
 import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.testng.internal.BaseTestMethod;
-import org.testng.internal.TestResult;
 
 import io.mosip.testrig.apirig.dbaccess.DBManager;
 import io.mosip.testrig.apirig.dto.OutputValidationDto;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PutWithPathParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/PutWithPathParam.java
@@ -1,6 +1,5 @@
 package io.mosip.testrig.apirig.prereg.testscripts;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -17,8 +16,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.testng.internal.BaseTestMethod;
-import org.testng.internal.TestResult;
 
 import io.mosip.testrig.apirig.dto.OutputValidationDto;
 import io.mosip.testrig.apirig.dto.TestCaseDTO;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/SimplePost.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/SimplePost.java
@@ -1,6 +1,5 @@
 package io.mosip.testrig.apirig.prereg.testscripts;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -17,8 +16,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.testng.internal.BaseTestMethod;
-import org.testng.internal.TestResult;
 
 import io.mosip.testrig.apirig.dto.OutputValidationDto;
 import io.mosip.testrig.apirig.dto.TestCaseDTO;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/UpdatePrereg.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testscripts/UpdatePrereg.java
@@ -1,6 +1,5 @@
 package io.mosip.testrig.apirig.prereg.testscripts;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -18,8 +17,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.testng.internal.BaseTestMethod;
-import org.testng.internal.TestResult;
 
 import io.mosip.testrig.apirig.dto.OutputValidationDto;
 import io.mosip.testrig.apirig.dto.TestCaseDTO;

--- a/api-test/src/main/resources/config/application.properties
+++ b/api-test/src/main/resources/config/application.properties
@@ -3,84 +3,21 @@ encryptionPath=v1/identity/encrypt?isInternal=false
 internalEncryptionPath=v1/identity/encrypt?isInternal=true
 encodePath=v1/identity/encode
 decodePath=v1/identity/decode
-signRequest=v1/identity/signRequest
 decryptPath=/idauthentication/v1/internal/decrypt
-decryptkycdataurl = v1/identity/decryptEkycData
 encodeFilePath=v1/identity/encodeFile
 decodeFilePath=v1/identity/decodeFile/?fileName=cbeff
 validateSignaturePath=v1/identity/validateSign?signature=$signature$
 splitEncryptedData=v1/identity/splitEncryptedData
-bioValueEncryptionTemplate=config/bioValueEncryptionTemplate.json
-idaMappingPath=config/mapping.properties
-getIdaCertificateUrl=/idauthentication/v1/internal/getCertificate
-getPartnerCertificateUrl=/v1/partnermanager/partners/{partnerId}/certificate
-putPartnerRegistrationUrl=/v1/partnermanager/partners
-getPartnerCertURL=v1/identity/generatePartnerKeys
-uploadCACertificateUrl=/v1/partnermanager/partners/certificate/ca/upload
-uploadIntermediateCertificateUrl=/v1/partnermanager/partners/certificate/ca/upload
-uploadPartnerCertificateUrl=/v1/partnermanager/partners/certificate/upload
-uploadSignedCertificateUrl=v1/identity/updatePartnerCertificate
-getKeyCloakTokenUrl = /auth/realms/master/protocol/openid-connect/token
 masterSchemaURL=/v1/masterdata/idschema/latest
 preregLoginConfigUrl=/preregistration/v1/login/config
-uploadIdaFirurl=v1/identity/uploadIDACertificate?certificateType=IDA_FIR&moduleName=$MODULENAME$&certsDir=$CERTSDIR$
-uploadPartnerurl=v1/identity/uploadIDACertificate?certificateType=PARTNER&moduleName=$MODULENAME$&certsDir=$CERTSDIR$
-uploadInternalurl=v1/identity/uploadIDACertificate?certificateType=INTERNAL&moduleName=$MODULENAME$&certsDir=$CERTSDIR$
-authPolicyUrl=/v1/policymanager/policies
-policyGroupUrl=/v1/policymanager/policies/group/new
-publishPolicyurl=/v1/policymanager/policies/POLICYID/group/POLICYGROUPID/publish
-clearCertificateURL=v1/identity/clearKeys?moduleName=$MODULENAME$&certsDir=$CERTSDIR$
-fetchLocationData=/v1/masterdata/locations/all
-fetchLocationLevel=/v1/masterdata/locations/level/
-fetchTitle=/v1/masterdata/title
-fetchZoneCode=/v1/masterdata/zones/hierarchy/
-fetchZone=/v1/masterdata/zones/zonename
-decryptKycUrl=/v1/identity/decryptEkycData
-retrieveIdByUin=/idrepository/v1/identity/idvid/
-fetchLocationHierarchyLevels=/v1/masterdata/locationHierarchyLevels/
-fetchLocationHierarchy=/v1/masterdata/locations/locationhierarchy/
-generateArgon2HashURL=/v1/keymanager/generateArgon2Hash
 appointmentavailabilityurl=/preregistration/v1/appointment/availability/
-validateSignatureUrl=v1/identity/validateSign
-vciContextURL=https://www.w3.org/2018/credentials/v1
-
-## As below are non changble values, move these out from properties file
-appIdForCertificate=IDA
-partnerrefId=PARTNER
-internalrefId=INTERNAL
-idaFirRefId=IDA-FIR
-proxyOTP=111111
-wrongOtp=123455
 
 ## 
 regcentretobookappointment=10003
-keysToValidateInKYC=phoneNumber,emailId,age,dob,name_eng
-#partner certificate refId, used for getting the partner certificate
-partner=9998
-signatureheaderKey=response-signature
-uinGenMaxLoopCount=20
-uinGenDelayTime=10000
-Delaytime=90000
-
-
-## Remove this from properties file
-picturevalue=iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAABCSURBVChTbYtBEgAgCAL7/6eNhBy09qDi6gpjXZSxUU8o/jrfpDmcmY1QAOWhgTswv6sSm8zVhULlgst++8T51IjYNUHdI+4XZHoAAAAASUVORK5CYII=
-
 
 ## Check are we using these properties. If not remove them
-zoneCode_to_beMapped=NTH
-expireOtpTime=180000
 demoAppVersion=1.2.1-java21-SNAPSHOT
-AttributetoBeUpdate:Name
-ValuetoBeUpdate:Sohan
 
 ## As these will be based on regEx, move these out from proprties file
 passwordForAddIdentity=12341234_Aa
 passwordToReset=12341234_AaB
-
-## Need to revisit these propeties
-XSRFTOKEN=7d01b2a8-b89d-41ad-9361-d7f6294021d1
-codeChallenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
-codeVerifier=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
-policyNumberForSunBirdRC=654321
-challengeValueForSunBirdRC=eyJmdWxsTmFtZSI6IkthaWYgU2lkZGlxdWUiLCJkb2IiOiIyMDAwLTA3LTI2In0=


### PR DESCRIPTION
Performed cleanup of unused configuration files and properties in the PREREG API Test Rig module.
- Verified all files under src/main/resources/config.
- Verified property usage in application.properties and removed unused entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code maintenance through dependency cleanup across test modules.
  * Updated password reset configuration value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->