### PR TITLE
Revert "[MOSIP-44617] Fixed "Mandatory fields are missing" error in sendNotifications API"

### DIFF
--- a/pre-registration/pre-registration-application-service/src/main/java/io/mosip/preregistration/application/service/util/NotificationServiceUtil.java
+++ b/pre-registration/pre-registration-application-service/src/main/java/io/mosip/preregistration/application/service/util/NotificationServiceUtil.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.json.JSONException;
@@ -136,18 +135,14 @@ public class NotificationServiceUtil {
 		NotificationDTO notificationDto = null;
 		List<KeyValuePairDto<String, String>> langaueNamePairs = new ArrayList<KeyValuePairDto<String, String>>();
 		if (isLatest) {
-			Map<String, Object> result = objectMapper.readValue(notificationDtoData.toString(),
-					new TypeReference<Map<String, Object>>() {
-					});
-			for (Map.Entry<String, Object> entry : result.entrySet()) {
-				KeyValuePairDto<String, String> pair = new KeyValuePairDto<>();
-				NotificationDTO dto = objectMapper.convertValue(entry.getValue(), NotificationDTO.class);
-
-				pair.setKey(entry.getKey());
-				pair.setValue(dto.getName());
-				langaueNamePairs.add(pair);
-
-				notificationDto = dto;
+			HashMap<String, String> result = objectMapper.readValue(notificationDtoData.toString(), HashMap.class);
+			KeyValuePairDto langaueNamePair = null;
+			for (Map.Entry<String, String> set : result.entrySet()) {
+				langaueNamePair = new KeyValuePairDto();
+				notificationDto = objectMapper.convertValue(set.getValue(), NotificationDTO.class);
+				langaueNamePair.setKey(set.getKey());
+				langaueNamePair.setValue(notificationDto.getName());
+				langaueNamePairs.add(langaueNamePair);
 			}
 			if (notificationDto != null) {
 				notificationDto.setFullName(langaueNamePairs);


### PR DESCRIPTION
Reverts mosip/pre-registration#1032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal notification data transformation logic for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->