### PR TITLE
MOSIP-44709: Fixed HealthCheck module mapping by using normalized module name instead of prefixed identifier.

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/prereg/testrunner/MosipTestRunner.java
@@ -83,7 +83,7 @@ public class MosipTestRunner {
 			setLogLevels();
 
 			HealthChecker healthcheck = new HealthChecker();
-			healthcheck.setCurrentRunningModule(BaseTestCase.currentModule);
+			healthcheck.setCurrentRunningModule(GlobalConstants.PREREG);
 			Thread trigger = new Thread(healthcheck);
 			trigger.start();
 			


### PR DESCRIPTION
Fixes HealthCheck module mismatch by replacing the prefixed module name (BaseTestCase.currentModule) with a normalized value (GlobalConstants.PREREG), ensuring correct mapping with healthCheckEndpoint.properties and proper endpoint filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed module identification in health-check monitoring for the test runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->