### PR TITLE
fix: rename core RegAppointmentRepository bean to avoid batchjob startup collision [MOSIP-44379]

### DIFF
--- a/pre-registration/pre-registration-core/src/main/java/io/mosip/preregistration/core/common/repository/RegAppointmentRepository.java
+++ b/pre-registration/pre-registration-core/src/main/java/io/mosip/preregistration/core/common/repository/RegAppointmentRepository.java
@@ -7,7 +7,14 @@ import org.springframework.stereotype.Repository;
 import io.mosip.kernel.core.dataaccess.spi.repository.BaseRepository;
 import io.mosip.preregistration.core.common.entity.RegistrationBookingEntity;
 
-@Repository("regAppointmentRepository")
+/**
+ * Bean name is deliberately core-scoped. pre-registration-batchjob declares its
+ * own {@code io.mosip.preregistration.batchjob.repository.RegAppointmentRepository}
+ * as {@code @Repository("regAppointmentRepository")}; both are picked up by the
+ * kernel's {@code @EnableJpaRepositories}, and an unqualified name here collides
+ * and fails batchjob startup.
+ */
+@Repository("coreRegAppointmentRepository")
 public interface RegAppointmentRepository extends BaseRepository<RegistrationBookingEntity, String> {
 
 	@Query("SELECT e FROM RegistrationBookingEntity e WHERE e.preregistrationId = ?1")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a repository naming conflict to improve application startup and component resolution.
  * Updated the repository’s registered name for consistent integration with related services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->